### PR TITLE
CORSの設定をconfigに移動します

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,13 +30,5 @@ module Poptweet
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins 'http://localhost:3000'
-        resource '*',
-        :headers => :any,
-        :methods => [:get, :post, :patch, :delete, :options]
-      end
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module Poptweet
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    config.x.cors_allowed_origins = ENV.fetch('CORS_ALLOWED_ORIGINS', 'localhost:3000')
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,14 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins Rails.application.config.x.cors_allowed_origins
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end
+

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,9 +7,9 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+# Specifies the `port` that Puma will listen on to receive requests; default is 4000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 4000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## 概要
参考: https://qiita.com/IzumiSy/items/c10949e9a00d1c61613c
CORSの設定を`config/application.rb`に設定していましたが、
本来設定されるべき`config/initializers/cors.rb`に移動します。
また、poptweet-apiのlocalhostのportを4000にし、Frontendのlocalhostのportと被らないにします

## 注意・伝達事項
 - 設定が合っているかの確認

## テストコードが追加しているか?ない場合はその理由、または動作テストの記録(エビデンス)を記載
設定変更のみのため、不要と判断

## その他・備考
 - [ ] UIの変更が生じる場合など、ユーザ通知やヘルプへの反映が必要か確認する。必要ならば対応する
 - [ ] 既存データが新しいルールに抵触しないことを確認した。（必要ならデータメンテナンスの手順を記載する）
